### PR TITLE
Fix/upload ipfs non directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,9 @@ async function main() {
           console.error(`Failed to process image for token ${token.symbol}:`, err)
           console.error(`Token details:`, token)
           console.warn(` Retrying ${attempt + 1} of ${10}`)
+          if (attempt == 10) {
+            throw (err)
+          }
         }
       }
       

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ async function main() {
         } catch (err) {
           console.error(`Failed to process image for token ${token.symbol}:`, err)
           console.error(`Token details:`, token)
-          console.warn(` Retrying ${attempt + 1} of ${5}`)
+          console.warn(` Retrying ${attempt + 1} of ${10}`)
         }
       }
       

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,7 +88,7 @@ async function main() {
           for (let attemptIPFS = 1; attemptIPFS <= 5; attemptIPFS++) {
             try {
               ipfsResponse = await ipfsPublish(
-                `${token.symbol}.png`,
+                `${token.symbol}`,
                 resizedImageBuffer,
               )
               console.info(` Done.`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,73 +68,76 @@ async function main() {
     } else {
       const imageUrl = `${process.env.IPFS_GATEWAY}${token.logoURI}`
       console.info(`Fetching image from URL: ${imageUrl}`)
-      const imageBuffer = await (await fetch(imageUrl)).buffer()
-
-      try {
-        const imageSharp = sharp(imageBuffer)
-        const metadata = await imageSharp.metadata()
-
-        console.debug(`Image metadata:`, metadata)
-
-        if (!metadata.format) {
-          throw new Error('Unsupported image format')
-        }
-
-        const resizedImageBuffer = await imageSharp.resize(64, 64).png().toBuffer()
-
-        console.info(` Pinning shrunk image to ${process.env.IPFS_GATEWAY}`)
-        let ipfsResponse: IPFSResponse[] | null = null
-
-        for (let attempt = 1; attempt <= 10; attempt++) {
-          try {
-            ipfsResponse = await ipfsPublish(
-              `${token.symbol}.png`,
-              resizedImageBuffer,
-            )
-            console.info(` Done.`)
-            break
-          } catch (err) {
-            console.warn(
-              ` Failed to upload ${token.symbol} to gateway IPFS.`,
-              err,
-            )
-            if (attempt === 5) {
-              console.error(
-                ` Could not upload ${token.symbol} image to gateway IPFS after 5 attempts.`,
+      for (let attempt = 1; attempt <= 10; attempt++) {
+        try {
+          const imageBuffer = await (await fetch(imageUrl)).buffer()
+          const imageSharp = sharp(imageBuffer)
+          const metadata = await imageSharp.metadata()
+  
+          console.debug(`Image metadata:`, metadata)
+  
+          if (!metadata.format) {
+            throw new Error('Unsupported image format')
+          }
+  
+          const resizedImageBuffer = await imageSharp.resize(64, 64).png().toBuffer()
+  
+          console.info(` Pinning shrunk image to ${process.env.IPFS_GATEWAY}`)
+          let ipfsResponse: IPFSResponse[] | null = null
+  
+          for (let attemptIPFS = 1; attemptIPFS <= 5; attemptIPFS++) {
+            try {
+              ipfsResponse = await ipfsPublish(
+                `${token.symbol}.png`,
+                resizedImageBuffer,
               )
-            } else {
-              console.warn(` Retrying ${attempt + 1} of ${5}`)
+              console.info(` Done.`)
+              break
+            } catch (err) {
+              console.warn(
+                ` Failed to upload ${token.symbol} to gateway IPFS.`,
+                err,
+              )
+              if (attemptIPFS === 5) {
+                console.error(
+                  ` Could not upload ${token.symbol} image to gateway IPFS after 5 attempts.`,
+                )
+              } else {
+                console.warn(` Retrying ${attemptIPFS + 1} of ${5}`)
+              }
             }
           }
+  
+          if (!ipfsResponse) {
+            console.error()
+            throw new Error(
+              `Failed to upload ${token.symbol} image to ipfs gateway. Halting`,
+            )
+          }
+  
+          const multihash = ipfsResponse[0].hash 
+  
+          if (ipfsResponse) {
+            // Was successfully pinned to IPFS, no point in resubmitting.
+            console.log(` Caching ${multihash}`)
+            await db.put(
+              cacheName(token.logoURI as string, token.symbol),
+              multihash,
+            )
+          }
+  
+          tokensWithLogo.push({
+            ...token,
+            logoURI: `ipfs://${multihash}`,
+          })
+          break
+        } catch (err) {
+          console.error(`Failed to process image for token ${token.symbol}:`, err)
+          console.error(`Token details:`, token)
+          console.warn(` Retrying ${attempt + 1} of ${5}`)
         }
-
-        if (!ipfsResponse) {
-          console.error()
-          throw new Error(
-            `Failed to upload ${token.symbol} image to ipfs gateway. Halting`,
-          )
-        }
-
-        const multihash = ipfsResponse[0].hash 
-
-        if (ipfsResponse) {
-          // Was successfully pinned to IPFS, no point in resubmitting.
-          console.log(` Caching ${multihash}`)
-          await db.put(
-            cacheName(token.logoURI as string, token.symbol),
-            multihash,
-          )
-        }
-
-        tokensWithLogo.push({
-          ...token,
-          logoURI: `ipfs://${multihash}`,
-        })
-      } catch (err) {
-        console.error(`Failed to process image for token ${token.symbol}:`, err)
-        console.error(`Token details:`, token)
-        throw err  // stop execution on error
       }
+      
     }
   }
 

--- a/src/utils/ipfs-publish.ts
+++ b/src/utils/ipfs-publish.ts
@@ -16,7 +16,7 @@ async function ipfsPublish(
 ): Promise<{ hash: string; path: string }[]> {  // Return an array of objects with a hash property
   const buffer = Buffer.from(data);
 
-  const cid = await filebase.storeDirectory([new File([buffer], fileName)]);
+  const cid = await filebase.storeBlob(new File([buffer], fileName), fileName);
   
   return [{ hash: cid, path: `${cid}/${fileName}` }];  // Return an array
 }


### PR DESCRIPTION
Change behavior of uploadToIPFS to store plain files instead of wrapping them into directories. At the same time, specifying the token name as name of the file so is easily to detect them in the filebase token.

The main reason of this change is to have a shorter logoURI to avoid having to define a logoURI as `"ipfs://QmfHKwGZ5wrYH6wt4cFZnoQDL9gf4cQaBM3ditLzDt8BJd/Mononoke-Inu.png"`