### PR TITLE
Handle missing caipAddress and other fields

### DIFF
--- a/src/utils/get-tokens.ts
+++ b/src/utils/get-tokens.ts
@@ -95,6 +95,10 @@ export default async function getTokens(): Promise<TokenInfo[]> {
     const decimals = token?.metadata?.props.find((p) => p.label === 'Decimals')
       ?.value as string
 
+    if (!caipAddress || !name || !symbol || !decimals) {
+      continue
+    }
+    
     const [namespace] = caipAddress.split(':')
     if (namespace !== 'eip155') {
       nonEvmTokens.push(caipAddress)


### PR DESCRIPTION
Some tokens are missing `caipAddress` in the subgraph, which breaks the run.

```
Unhandled error: TypeError: Cannot read properties of undefined (reading 'split')
    at /home/ubuntu/t2cr-to-ipfs/src/utils/get-tokens.ts:98:37
    at Generator.next (<anonymous>)
    at fulfilled (/home/ubuntu/t2cr-to-ipfs/build/utils/get-tokens.js:5:58)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

For good measure I have also added a check for the other fields `name` `symbol` `decimals`, but not sure if they are allowed to be missing.